### PR TITLE
Allow multiple patterns to match files

### DIFF
--- a/src/sitemap.coffee
+++ b/src/sitemap.coffee
@@ -45,7 +45,7 @@ module.exports = (grunt) ->
 		priority = (@data.priority or 0.5).toString()
 
 		# File pattern
-		pattern = path.join root, (@data.pattern or '/**/*.html')
+		pattern = this.data.pattern or path.join root, '/**/*.html'
 		
 		# Glob root
 		files = grunt.file.expand pattern


### PR DESCRIPTION
Allow multiple patterns using an array as an option:

```
sitemap: {
  dist: {
    pattern: ['**/*.html','!ignore_this_folder/*.html']
  }
}
```
