### PR TITLE
Making the path extension generated in xml, be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Set this to override `<priority>` in sitemap.
 
 #### extension
 
-* Type: `bollean`
+* Type: `boolean`
 * Default: `true`
 
 By default the `<loc>` is generated with a path that contains extension.

--- a/README.md
+++ b/README.md
@@ -86,5 +86,14 @@ Set this to override `<changefreq>` in sitemap.
 
 Set this to override `<priority>` in sitemap.
 
+#### extension
+
+* Type: `bollean`
+* Default: `true`
+
+By default the `<loc>` is generated with a path that contains extension.
+Eg: '.hmlt' or '.htm'.
+To make your path without extension just add `false` for this **extension** attribute.
+
 ## Contributing
 We accept pull requests! A special thanks to XhmikosR for keeping things rolling.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Set this to override `<changefreq>` in sitemap.
 
 Set this to override `<priority>` in sitemap.
 
-#### extension without trailing slash
+#### extension
 
 * Type: `object`
 * Default: `{ required: true }`
@@ -99,9 +99,7 @@ extension: {
 }
 ````
 
-and if you need to have the bar at the end of the url simply add the attribute `trailingSlash: true`
-
-Eg.
+and if you need to trailing slash simply add the attribute `trailingSlash: true` Eg.
 
 ````javascript
 extension: {

--- a/README.md
+++ b/README.md
@@ -86,14 +86,33 @@ Set this to override `<changefreq>` in sitemap.
 
 Set this to override `<priority>` in sitemap.
 
-#### extension
+#### extension without trailing slash
 
-* Type: `boolean`
-* Default: `true`
+* Type: `object`
+* Default: `{ required: true }`
+
+Eg.
+
+````javascript
+extension: {
+  required: false
+}
+````
+
+and if you need to have the bar at the end of the url simply add the attribute `trailingSlash: true`
+
+Eg.
+
+````javascript
+extension: {
+  required: false
+  trailingSlash: true
+}
+````
 
 By default the `<loc>` is generated with a path that contains extension.
 Eg: '.hmlt' or '.htm'.
-To make your path without extension just add `false` for this **extension** attribute.
+To make your path without extension just add `extension: { required: false }` for this **required** of extension attribute.
 
 ## Contributing
 We accept pull requests! A special thanks to XhmikosR for keeping things rolling.

--- a/src/sitemap.coffee
+++ b/src/sitemap.coffee
@@ -76,13 +76,13 @@ module.exports = (grunt) ->
 			if rawUrlPath.indexOf('/') is 0 then rawUrlPath = rawUrlPath.replace '/', ''
 
 			urlPath = if extension
+				# Remove index.html
+				rawUrlPath.replace /(index)\.[A-z]+$/, '', 'i'
+			else
 				# Remove extension
 				rawUrlPath
 					.replace /(index)\.[A-z]+$/, '', 'i'
 					.replace /\.html/, '/', 'i'
-			else
-				# Remove index.html
-				rawUrlPath.replace /(index)\.[A-z]+$/, '', 'i'
 
 			# Join path with homepage url
 			fileStat.url = url + urlPath

--- a/src/sitemap.coffee
+++ b/src/sitemap.coffee
@@ -4,7 +4,6 @@
 # Licensed under the MIT license.
 
 module.exports = (grunt) ->
-
 	# Node modules
 	path = require 'path'
 	fs = require 'fs'
@@ -44,6 +43,9 @@ module.exports = (grunt) ->
 		# changereq setting
 		changefreq = @data.changefreq or 'daily'
 
+		# extension setting
+		extension = if @data.extension? then @data.extension else true
+
 		# priority setting
 		# Must be string
 		priority = (@data.priority or 0.5).toString()
@@ -73,8 +75,14 @@ module.exports = (grunt) ->
 			# since we add it in url
 			if rawUrlPath.indexOf('/') is 0 then rawUrlPath = rawUrlPath.replace '/', ''
 
-			# Remove index.html
-			urlPath = rawUrlPath.replace /(index)\.[A-z]+$/, '', 'i'
+			urlPath = if extension
+				# Remove extension
+				rawUrlPath
+					.replace /(index)\.[A-z]+$/, '', 'i'
+					.replace /\.html/, '/', 'i'
+			else
+				# Remove index.html
+				rawUrlPath.replace /(index)\.[A-z]+$/, '', 'i'
 
 			# Join path with homepage url
 			fileStat.url = url + urlPath

--- a/src/sitemap.coffee
+++ b/src/sitemap.coffee
@@ -44,7 +44,7 @@ module.exports = (grunt) ->
 		changefreq = @data.changefreq or 'daily'
 
 		# extension setting
-		extension = if @data.extension? then @data.extension else true
+		extension = if @data.extension? then @data.extension else { required: true }
 
 		# priority setting
 		# Must be string
@@ -75,14 +75,16 @@ module.exports = (grunt) ->
 			# since we add it in url
 			if rawUrlPath.indexOf('/') is 0 then rawUrlPath = rawUrlPath.replace '/', ''
 
-			urlPath = if extension
-				# Remove index.html
-				rawUrlPath.replace /(index)\.[A-z]+$/, '', 'i'
-			else
-				# Remove extension
-				rawUrlPath
-					.replace /(index)\.[A-z]+$/, '', 'i'
-					.replace /\.html/, '/', 'i'
+			# Remove index.html
+			rawUrlPath.replace /(index)\.[A-z]+$/, '', 'i'
+
+			urlPath = switch
+			    when typeof(extension) == 'object' && !extension.required && extension.trailingSlash
+			    	# Remove extension with trailing slash
+			    	rawUrlPath.replace /\.html/, '/', 'i'
+			    when typeof(extension) == 'object' && !extension.required && !extension.trailingSlash
+			    	# Remove extension without trailing slash
+			    	rawUrlPath.replace /\.html/, '', 'i'
 
 			# Join path with homepage url
 			fileStat.url = url + urlPath

--- a/src/sitemap.coffee
+++ b/src/sitemap.coffee
@@ -76,7 +76,7 @@ module.exports = (grunt) ->
 			if rawUrlPath.indexOf('/') is 0 then rawUrlPath = rawUrlPath.replace '/', ''
 
 			# Remove index.html
-			rawUrlPath.replace /(index)\.[A-z]+$/, '', 'i'
+			rawUrlPath = rawUrlPath.replace /(index)\.[A-z]+$/, '', 'i'
 
 			urlPath = switch
 			    when typeof(extension) == 'object' && !extension.required && extension.trailingSlash
@@ -85,6 +85,9 @@ module.exports = (grunt) ->
 			    when typeof(extension) == 'object' && !extension.required && !extension.trailingSlash
 			    	# Remove extension without trailing slash
 			    	rawUrlPath.replace /\.html/, '', 'i'
+			    else
+			    	# only return path with extension
+			    	rawUrlPath
 
 			# Join path with homepage url
 			fileStat.url = url + urlPath

--- a/tasks/sitemap.js
+++ b/tasks/sitemap.js
@@ -44,7 +44,7 @@
         if (rawUrlPath.indexOf('/') === 0) {
           rawUrlPath = rawUrlPath.replace('/', '');
         }
-        urlPath = extension ? rawUrlPath.replace(/(index)\.[A-z]+$/, '', 'i').replace(/\.html/, '/', 'i') : rawUrlPath.replace(/(index)\.[A-z]+$/, '', 'i');
+        urlPath = extension ? rawUrlPath.replace(/(index)\.[A-z]+$/, '', 'i') : rawUrlPath.replace(/(index)\.[A-z]+$/, '', 'i').replace(/\.html/, '/', 'i');
         fileStat.url = url + urlPath;
         mtime = (fs.statSync(file).mtime).getTime();
         fileStat.mtime = new Date(mtime).toISOString();

--- a/tasks/sitemap.js
+++ b/tasks/sitemap.js
@@ -46,13 +46,15 @@
         if (rawUrlPath.indexOf('/') === 0) {
           rawUrlPath = rawUrlPath.replace('/', '');
         }
-        rawUrlPath.replace(/(index)\.[A-z]+$/, '', 'i');
+        rawUrlPath = rawUrlPath.replace(/(index)\.[A-z]+$/, '', 'i');
         urlPath = (function() {
           switch (false) {
             case !(typeof extension === 'object' && !extension.required && extension.trailingSlash):
               return rawUrlPath.replace(/\.html/, '/', 'i');
             case !(typeof extension === 'object' && !extension.required && !extension.trailingSlash):
               return rawUrlPath.replace(/\.html/, '', 'i');
+            default:
+              return rawUrlPath;
           }
         })();
         fileStat.url = url + urlPath;

--- a/tasks/sitemap.js
+++ b/tasks/sitemap.js
@@ -26,7 +26,9 @@
         url += '/';
       }
       changefreq = this.data.changefreq || 'daily';
-      extension = this.data.extension != null ? this.data.extension : true;
+      extension = this.data.extension != null ? this.data.extension : {
+        required: true
+      };
       priority = (this.data.priority || 0.5).toString();
       pattern = this.data.pattern || path.join(root, '/**/*.html');
       files = grunt.file.expand(pattern);
@@ -44,7 +46,15 @@
         if (rawUrlPath.indexOf('/') === 0) {
           rawUrlPath = rawUrlPath.replace('/', '');
         }
-        urlPath = extension ? rawUrlPath.replace(/(index)\.[A-z]+$/, '', 'i') : rawUrlPath.replace(/(index)\.[A-z]+$/, '', 'i').replace(/\.html/, '/', 'i');
+        rawUrlPath.replace(/(index)\.[A-z]+$/, '', 'i');
+        urlPath = (function() {
+          switch (false) {
+            case !(typeof extension === 'object' && !extension.required && extension.trailingSlash):
+              return rawUrlPath.replace(/\.html/, '/', 'i');
+            case !(typeof extension === 'object' && !extension.required && !extension.trailingSlash):
+              return rawUrlPath.replace(/\.html/, '', 'i');
+          }
+        })();
         fileStat.url = url + urlPath;
         mtime = (fs.statSync(file).mtime).getTime();
         fileStat.mtime = new Date(mtime).toISOString();

--- a/tasks/sitemap.js
+++ b/tasks/sitemap.js
@@ -7,7 +7,7 @@
     _ = require('lodash');
     slash = require('slash');
     return grunt.registerMultiTask('sitemap', 'sitemap description', function() {
-      var changefreq, file, files, homeErrMess, pattern, pkg, priority, root, rootWarnMess, sitemapPath, url, xmlStr, _i, _len;
+      var changefreq, extension, file, files, homeErrMess, pattern, pkg, priority, root, rootWarnMess, sitemapPath, url, xmlStr, _i, _len;
       pkg = grunt.file.readJSON('package.json');
       url = this.data.homepage || pkg.homepage;
       homeErrMess = 'Requires "homepage" parameter. Sitemap was not created.';
@@ -26,6 +26,7 @@
         url += '/';
       }
       changefreq = this.data.changefreq || 'daily';
+      extension = this.data.extension != null ? this.data.extension : true;
       priority = (this.data.priority || 0.5).toString();
       pattern = this.data.pattern || path.join(root, '/**/*.html');
       files = grunt.file.expand(pattern);
@@ -43,7 +44,7 @@
         if (rawUrlPath.indexOf('/') === 0) {
           rawUrlPath = rawUrlPath.replace('/', '');
         }
-        urlPath = rawUrlPath.replace(/(index)\.[A-z]+$/, '', 'i');
+        urlPath = extension ? rawUrlPath.replace(/(index)\.[A-z]+$/, '', 'i').replace(/\.html/, '/', 'i') : rawUrlPath.replace(/(index)\.[A-z]+$/, '', 'i');
         fileStat.url = url + urlPath;
         mtime = (fs.statSync(file).mtime).getTime();
         fileStat.mtime = new Date(mtime).toISOString();


### PR DESCRIPTION
By default the `<loc>` is value the `file.html`.
Eg:

````xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
	xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
<url>

  <!-- the change influence this value -->
  <loc>foo.com/bar.html</loc>
  <!-- ------------------- -->

  <lastmod>2014-12-30T02:38:50.000Z</lastmod>
  <changefreq>daily</changefreq>
  <priority>0.5</priority>
</url>
</urlset>
````

I'm inserting a **extension attribute** that by default is true but if it is changed to false, the `.html` shall be replaced by `/`
Eg:
````xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
	xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
<url>

  <!-- value changed when extension is false -->
  <loc>foo.com/bar/</loc>
  <!-- ------------------- -->

  <lastmod>2014-12-30T02:38:50.000Z</lastmod>
  <changefreq>daily</changefreq>
  <priority>0.5</priority>
</url>
</urlset>
````

#### Implementation

````javascript
sitemap: {
      dist: {
          siteRoot: 'dist/',
          extension: false
      }
}
````