### PR TITLE
Added missing comma in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ If you need a trailing slash just set the attribute `trailingSlash: true` Eg.
 
 ````js
 extension: {
-  required: false
+  required: false,
   trailingSlash: true
 }
 ````


### PR DESCRIPTION
Just added one comma, reduces copy&paste errors from the documentation. :-)