### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,7 @@
   "bugs": {
     "url": "https://github.com/RayViljoen/grunt-sitemap/issues"
   },
-  "license": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/RayViljoen/grunt-sitemap/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "keywords": [
     "gruntplugin",
     "sitemap",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license